### PR TITLE
Move environment configuration to a ConfigMap

### DIFF
--- a/base/deployment.yaml
+++ b/base/deployment.yaml
@@ -22,9 +22,9 @@ spec:
           volumeMounts:
             - name: shared-data
               mountPath: /shared_data
-          env:
-            - name: OUTPUT_DIR
-              value: "/shared_data/output"
+          envFrom:
+            - configMapRef:
+                name: llm-load-test-config
           resources:
             requests:
               cpu: 100m
@@ -50,19 +50,9 @@ spec:
           volumeMounts:
             - name: shared-data
               mountPath: /shared_data
-          env:
-            - name: OUTPUT_DIR
-              value: "/shared_data/output"
-            - name: WAIT_TIME
-              value: "120"
-            - name: CONCURRENCY
-              value: "8"
-            - name: DURATION
-              value: "30"
-            - name: STREAMING
-              value: "true"
-            - name: ENDPOINT
-              value: "/v1/chat/completions"
+          envFrom:
+            - configMapRef:
+                name: llm-load-test-config
           resources:
             requests:
               cpu: 200m

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -17,4 +17,7 @@ configMapGenerator:
     options:
       disableNameSuffixHash: true
     files:
-    - files/uwl_metrics_list.yaml
+      - files/uwl_metrics_list.yaml
+  - name: llm-load-test-config
+    envs:
+      - files/llm-load-test-config.env


### PR DESCRIPTION
This moves the environment configuration out of the Deployment manifest and
into a separate ConfigMap.

- It allows us to use Kustomize's configMapGenerator support and a simple
  environment file to define the environment variables. An environment
  file looks like this:

       OUTPUT_DIR=/shared_data/output
       WAIT_TIME=120
       CONCURRENCY=8
       DURATION=30
       STREAMING=true
       ENDPOINT=/v1/chat/completions

  This is simpler than directly editing the Deployment manifest.

- Because we are *not* disabling the suffix that Kustomize adds to
  ConfigMap names, editing the environment file and re-deploying with
  Kustomize will cause the Deployment to restart, activating the new
  configuration.
